### PR TITLE
Time boundary calculation for SSQE.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -55,9 +55,6 @@ import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.querylog.QueryLogger;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
-import org.apache.pinot.query.routing.table.ImplicitHybridTableRouteProvider;
-import org.apache.pinot.query.routing.table.LogicalTableRouteProvider;
-import org.apache.pinot.query.routing.table.TableRouteProvider;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.http.MultiHttpRequest;
 import org.apache.pinot.common.http.MultiHttpRequestResponse;
@@ -91,6 +88,9 @@ import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.TableRouteInfo;
 import org.apache.pinot.core.util.GapfillUtils;
 import org.apache.pinot.query.parser.utils.ParserUtils;
+import org.apache.pinot.query.routing.table.ImplicitHybridTableRouteProvider;
+import org.apache.pinot.query.routing.table.LogicalTableRouteProvider;
+import org.apache.pinot.query.routing.table.TableRouteProvider;
 import org.apache.pinot.segment.local.function.GroovyFunctionEvaluator;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -481,7 +481,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       // Hybrid
       PinotQuery offlinePinotQuery = serverPinotQuery.deepCopy();
       offlinePinotQuery.getDataSource().setTableName(offlineTableName);
-      assert timeBoundaryInfo != null;
+      Preconditions.checkArgument(timeBoundaryInfo != null,
+          "Time boundary info should not be null for hybrid table: %s", offlineTableName);
       attachTimeBoundary(offlinePinotQuery, timeBoundaryInfo, true);
       handleExpressionOverride(offlinePinotQuery, _tableCache.getExpressionOverrideMap(offlineTableName));
       handleTimestampIndexOverride(offlinePinotQuery, offlineTableConfig);
@@ -490,6 +491,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
       PinotQuery realtimePinotQuery = serverPinotQuery.deepCopy();
       realtimePinotQuery.getDataSource().setTableName(realtimeTableName);
+      attachTimeBoundary(realtimePinotQuery, timeBoundaryInfo, false);
       handleExpressionOverride(realtimePinotQuery, _tableCache.getExpressionOverrideMap(realtimeTableName));
       handleTimestampIndexOverride(realtimePinotQuery, realtimeTableConfig);
       _queryOptimizer.optimize(realtimePinotQuery, realtimeTableConfig, schema);

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
+import org.apache.arrow.util.Preconditions;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.helix.AccessOption;
@@ -195,7 +196,15 @@ public class TableCache implements PinotConfigProvider {
    */
   @Nullable
   public Map<String, String> getColumnNameMap(String rawTableName) {
-    SchemaInfo schemaInfo = _schemaInfoMap.get(rawTableName);
+    SchemaInfo schemaInfo;
+    if (isLogicalTable(rawTableName)) {
+      LogicalTable logicalTable = getLogicalTable(rawTableName);
+      Preconditions.checkArgument(logicalTable != null, "Logical table should not be null");
+      String physicalTableName = logicalTable.getPhysicalTableNames().get(0);
+      schemaInfo = _schemaInfoMap.get(TableNameBuilder.extractRawTableName(physicalTableName));
+    } else {
+      schemaInfo = _schemaInfoMap.get(rawTableName);
+    }
     return schemaInfo != null ? schemaInfo._columnNameMap : null;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.timeboundary;
+
+import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.routing.TimeBoundaryInfo;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+public class MinTimeBoundaryStrategy implements TimeBoundaryStrategy {
+  private final Set<String> _includedTables;
+  private final Set<String> _excludedTables;
+
+  public MinTimeBoundaryStrategy(Map<String, Object> parameters) {
+    _includedTables = new HashSet<>((List<String>) parameters.get("includedTables"));
+    _excludedTables = new HashSet<>((List<String>) parameters.get("excludedTables"));
+  }
+
+  @Override
+  public TimeBoundaryInfo computeTimeBoundary(TableCache tableCache, List<String> physicalTableNames,
+      RoutingManager routingManager) {
+    TimeBoundaryInfo minTimeBoundaryInfo = null;
+    long minTimeBoundary = Long.MAX_VALUE;
+    for (String physicalTableName : physicalTableNames) {
+      TimeBoundaryInfo current = routingManager.getTimeBoundaryInfo(physicalTableName);
+      if (current != null && (_includedTables.isEmpty() || _includedTables.contains(physicalTableName))
+          && !_excludedTables.contains(physicalTableName)) {
+        String rawTableName = TableNameBuilder.extractRawTableName(physicalTableName);
+        Schema schema = tableCache.getSchema(rawTableName);
+        TableConfig tableConfig = tableCache.getTableConfig(physicalTableName);
+        Preconditions.checkArgument(tableConfig != null,
+            "Table config not found for table: %s", physicalTableName);
+        Preconditions.checkArgument(schema != null,
+            "Schema not found for table: %s", physicalTableName);
+        String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+        DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
+        Preconditions.checkArgument(dateTimeFieldSpec != null,
+            "Time column not found in schema for table: %s", physicalTableName);
+        DateTimeFormatSpec specFormatSpec = dateTimeFieldSpec.getFormatSpec();
+        long currentTimeBoundaryMillis = specFormatSpec.fromFormatToMillis(current.getTimeValue());
+        if (minTimeBoundaryInfo == null) {
+          minTimeBoundaryInfo = current;
+          minTimeBoundary = currentTimeBoundaryMillis;
+        } else if (minTimeBoundary > currentTimeBoundaryMillis) {
+          minTimeBoundaryInfo = current;
+          minTimeBoundary = currentTimeBoundaryMillis;
+        }
+      }
+    }
+    return minTimeBoundaryInfo;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategy.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.timeboundary;
+
+import java.util.List;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.routing.TimeBoundaryInfo;
+
+
+public interface TimeBoundaryStrategy {
+  TimeBoundaryInfo computeTimeBoundary(TableCache tableCache, List<String> physicalTableNames,
+      RoutingManager routingManager);
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategyFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategyFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.timeboundary;
+
+import org.apache.pinot.spi.data.TimeBoundaryConfig;
+
+
+public class TimeBoundaryStrategyFactory {
+
+  private TimeBoundaryStrategyFactory() {
+    // Prevent instantiation
+  }
+
+  public static TimeBoundaryStrategy createTimeBoundaryStrategy(TimeBoundaryConfig timeBoundaryConfig) {
+    switch (timeBoundaryConfig.getBoundaryStrategy().toLowerCase()) {
+      case "min":
+        return new MinTimeBoundaryStrategy(timeBoundaryConfig.getParameters());
+      default:
+        throw new IllegalArgumentException("Unknown time boundary strategy: " + timeBoundaryConfig);
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -243,10 +243,5 @@ public class MockRoutingManagerFactory {
     public Set<String> getServingInstances(String tableNameWithType) {
       return _serverInstances.keySet();
     }
-
-    @Override
-    public boolean isTableDisabled(String tableNameWithType) {
-      return _disabledTables.contains(tableNameWithType);
-    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/LogicalTable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/LogicalTable.java
@@ -35,6 +35,7 @@ public class LogicalTable implements Serializable {
   private String _tableName;
   private String _brokerTenant;
   private List<String> _physicalTableNames;
+  private TimeBoundaryConfig _timeBoundaryConfig;
 
   public static LogicalTable fromFile(File logicalTableFile)
       throws IOException {
@@ -70,6 +71,14 @@ public class LogicalTable implements Serializable {
     _physicalTableNames = physicalTableNames;
   }
 
+  public TimeBoundaryConfig getTimeBoundaryConfig() {
+    return _timeBoundaryConfig;
+  }
+
+  public void setTimeBoundaryConfig(TimeBoundaryConfig timeBoundaryConfig) {
+    _timeBoundaryConfig = timeBoundaryConfig;
+  }
+
   public ObjectNode toJsonObject() {
     ObjectNode node = JsonUtils.newObjectNode().put("tableName", _tableName).put("brokerTenant", _brokerTenant);
     ArrayNode arrayNode = JsonUtils.newArrayNode();
@@ -77,6 +86,9 @@ public class LogicalTable implements Serializable {
       arrayNode.add(physicalTableName);
     }
     node.set("physicalTableNames", arrayNode);
+    if (_timeBoundaryConfig != null) {
+      node.set("timeBoundaryConfig", _timeBoundaryConfig.toJsonNode());
+    }
     return node;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeBoundaryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeBoundaryConfig.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.util.Map;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+
+
+public class TimeBoundaryConfig extends BaseJsonConfig {
+  private String _boundaryStrategy;
+  private Map<String, Object> _parameters;
+
+  public String getBoundaryStrategy() {
+    return _boundaryStrategy;
+  }
+
+  public void setBoundaryStrategy(String boundaryStrategy) {
+    _boundaryStrategy = boundaryStrategy;
+  }
+
+  public Map<String, Object> getParameters() {
+    return _parameters;
+  }
+
+  public void setParameters(Map<String, Object> parameters) {
+    _parameters = parameters;
+  }
+}


### PR DESCRIPTION
Manual Testing
Time Boundary Computation (SSQE)

- Launch the Realtime Quickstart (Match the response to regular hybrid table equivalent queries)
  - Logical table with both offline and realtime tables
    - Include tables and exclude tables lists are empty
    - Include tables contain the offline table and exclude table empty
    - Include table empty and exclude table contains the offline table
  - Logical table with only offline table
  - Logical table with only realtime table

- Launch the LogicalTable Quickstart (Match the response to individual tables)
  - Logical table with two offline tables
  - Logical table with individual offline tables
